### PR TITLE
Refactor leaderboard logic to load by riderId instead of transponder

### DIFF
--- a/test/race.js
+++ b/test/race.js
@@ -330,7 +330,7 @@ test('should get leaderboard', async (t) => {
     .query({
       raceId: race._id,
     })
-  t.true(!emptyLeaderboard.passings)
+  t.true(!emptyLeaderboard.passings.length)
   await supertest(app)
     .post('/races/entry')
     .send({


### PR DESCRIPTION
Transponders can be rented and changed for riders at a future point in time. Leaderboards should be immutable.